### PR TITLE
Creating OperatorHub Manifests for Iter8

### DIFF
--- a/manifests/iter8-operator/1.0.0/experiment.crd.yaml
+++ b/manifests/iter8-operator/1.0.0/experiment.crd.yaml
@@ -1,0 +1,778 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  creationTimestamp: null
+  name: experiments.iter8.tools
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.experimentType
+    description: Type of experiment
+    format: byte
+    name: type
+    type: string
+  - JSONPath: .status.effectiveHosts
+    description: Names of candidates
+    format: byte
+    name: hosts
+    type: string
+  - JSONPath: .status.phase
+    description: Phase of the experiment
+    format: byte
+    name: phase
+    type: string
+  - JSONPath: .status.assessment.winner.winning_version_found
+    description: Winner identified
+    format: byte
+    name: winner found
+    type: boolean
+  - JSONPath: .status.assessment.winner.name
+    description: Current best version
+    format: byte
+    name: current best
+    type: string
+  - JSONPath: .status.assessment.winner.probability_of_winning_for_best_version
+    description: Confidence current bets version will be the winner
+    format: float
+    name: confidence
+    priority: 1
+    type: string
+  - JSONPath: .status.message
+    description: Detailed Status of the experiment
+    format: byte
+    name: status
+    type: string
+  - JSONPath: .spec.service.baseline
+    description: Name of baseline
+    format: byte
+    name: baseline
+    priority: 1
+    type: string
+  - JSONPath: .spec.service.candidates
+    description: Names of candidates
+    format: byte
+    name: candidates
+    priority: 1
+    type: string
+  group: iter8.tools
+  names:
+    kind: Experiment
+    listKind: ExperimentList
+    plural: experiments
+    singular: experiment
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Experiment contains the sections for -- defining an experiment,
+        showing experiment status,
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ExperimentSpec defines the desired state of Experiment
+          properties:
+            analyticsEndpoint:
+              description: Endpoint of reaching analytics service default is http://iter8-analytics:8080
+              type: string
+            cleanup:
+              description: Cleanup indicates whether routing rules and deployment
+                receiving no traffic should be deleted at the end of experiment
+              type: boolean
+            criteria:
+              description: Criteria contains a list of Criterion for assessing the
+                target service Noted that at most one reward metric is allowed If
+                more than one reward criterion is included, the first would be used
+                while others would be omitted
+              items:
+                description: Criterion defines the criterion for assessing a target
+                properties:
+                  isReward:
+                    description: IsReward indicates whether the metric is a reward
+                      metric or not
+                    type: boolean
+                  metric:
+                    description: Name of metric used in the assessment
+                    type: string
+                  threshold:
+                    description: Threshold specifies the numerical value for a success
+                      criterion Metric value above threhsold violates the criterion
+                    properties:
+                      cutoffTrafficOnViolation:
+                        description: Once a target metric violates this threshold,
+                          traffic to the target should be cutoff or not
+                        type: boolean
+                      type:
+                        description: 'Type of threshold relative: value of threshold
+                          specifies the relative amount of changes absolute: value
+                          of threshold indicates an absolute value'
+                        enum:
+                        - relative
+                        - absolute
+                        type: string
+                      value:
+                        description: Value of threshold
+                        format: float64
+                        type: number
+                    required:
+                    - type
+                    - value
+                    type: object
+                required:
+                - metric
+                type: object
+              type: array
+            duration:
+              description: Duration specifies how often/many times the expriment should
+                re-evaluate the assessment
+              properties:
+                interval:
+                  description: Interval specifies duration between iterations default
+                    is 30s
+                  type: string
+                maxIterations:
+                  description: MaxIterations indicates the amount of iteration default
+                    is 100
+                  format: int32
+                  type: integer
+              type: object
+            manualOverride:
+              description: User actions to override the current status of the experiment
+              properties:
+                action:
+                  description: Action to perform
+                  enum:
+                  - pause
+                  - resume
+                  - terminate
+                  type: string
+                trafficSplit:
+                  additionalProperties:
+                    format: int32
+                    type: integer
+                  description: 'Traffic split status specification Applied to action
+                    terminate only example:   reviews-v2:80   reviews-v3:20'
+                  type: object
+              required:
+              - action
+              type: object
+            metrics:
+              description: The metrics used in the experiment
+              properties:
+                counter_metrics:
+                  description: List of counter metrics definiton
+                  items:
+                    description: CounterMetric is the definition of Counter Metric
+                    properties:
+                      name:
+                        description: Name of metric
+                        type: string
+                      preferred_direction:
+                        description: Preferred direction of the metric value
+                        type: string
+                      query_template:
+                        description: Query template of this metric
+                        type: string
+                      unit:
+                        description: Unit of the metric value
+                        type: string
+                    required:
+                    - name
+                    - query_template
+                    type: object
+                  type: array
+                ratio_metrics:
+                  description: List of ratio metrics definiton
+                  items:
+                    description: RatioMetric is the definiton of Ratio Metric
+                    properties:
+                      denominator:
+                        description: Counter metric used in denominator
+                        type: string
+                      name:
+                        description: name of metric
+                        type: string
+                      numerator:
+                        description: Counter metric used in numerator
+                        type: string
+                      preferred_direction:
+                        description: Preferred direction of the metric value
+                        type: string
+                      zero_to_one:
+                        description: Boolean flag indicating if the value of this
+                          metric is always in the range 0 to 1
+                        type: boolean
+                    required:
+                    - denominator
+                    - name
+                    - numerator
+                    type: object
+                  type: array
+              type: object
+            networking:
+              description: Networking describes how traffic network should be configured
+                for the experiment
+              properties:
+                hosts:
+                  description: List of hosts used to receive external traffic
+                  items:
+                    description: Host holds the name of host and gateway associated
+                      with it
+                    properties:
+                      gateway:
+                        description: The gateway associated with the host
+                        type: string
+                      name:
+                        description: Name of the Host
+                        type: string
+                    required:
+                    - gateway
+                    - name
+                    type: object
+                  type: array
+                id:
+                  description: id of router
+                  type: string
+              type: object
+            service:
+              description: Service is a reference to the service componenets that
+                this experiment is targeting at
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                baseline:
+                  description: Name of the baseline deployment
+                  type: string
+                candidates:
+                  description: List of names of candidate deployments
+                  items:
+                    type: string
+                  type: array
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                port:
+                  description: Port number exposed by internal services
+                  format: int32
+                  type: integer
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              required:
+              - baseline
+              - candidates
+              type: object
+            trafficControl:
+              description: TrafficControl provides instructions on traffic management
+                for an experiment
+              properties:
+                match:
+                  description: Only requests fulfill the match section would be used
+                    in experiment Istio matching rules are used
+                  properties:
+                    http:
+                      description: Matching criteria for HTTP requests
+                      items:
+                        properties:
+                          authority:
+                            description: HTTP Authority
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                type: string
+                            type: object
+                          gateways:
+                            description: Gateways for matching
+                            items:
+                              type: string
+                            type: array
+                          headers:
+                            additionalProperties:
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  type: string
+                              type: object
+                            description: Headers to match
+                            type: object
+                          ignore_uri_case:
+                            description: Flag to specify whether the URI matching
+                              should be case-insensitive.
+                            type: boolean
+                          method:
+                            description: HTTP Method
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                type: string
+                            type: object
+                          name:
+                            description: The name assigned to a match.
+                            type: string
+                          port:
+                            description: Specifies the ports on the host that is being
+                              addressed.
+                            format: int32
+                            type: integer
+                          query_params:
+                            additionalProperties:
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                                regex:
+                                  type: string
+                              type: object
+                            description: Query parameters for matching.
+                            type: object
+                          scheme:
+                            description: Scheme Scheme
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                type: string
+                            type: object
+                          sourceLabels:
+                            additionalProperties:
+                              type: string
+                            description: SourceLabels for matching
+                            type: object
+                          uri:
+                            description: URI to match
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                              regex:
+                                type: string
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                maxIncrement:
+                  description: MaxIncrement is the upperlimit of traffic increment
+                    for a target in one iteration default is 2
+                  format: int32
+                  type: integer
+                onTermination:
+                  description: OnTermination determines traffic split status at the
+                    end of experiment
+                  enum:
+                  - to_winner
+                  - to_baseline
+                  - keep_last
+                  type: string
+                percentage:
+                  description: Percentage specifies the amount of traffic to service
+                    that would be used in experiment default is 100
+                  format: int32
+                  type: integer
+                routerID:
+                  description: RouterID refers to the id of router used to handle
+                    traffic for the experiment If it's not specified, the first entry
+                    of effictive host will be used as the id
+                  type: string
+                strategy:
+                  description: Strategy used to shift traffic default is progressive
+                  enum:
+                  - progressive
+                  - top_2
+                  - uniform
+                  type: string
+              type: object
+          required:
+          - service
+          type: object
+        status:
+          description: ExperimentStatus defines the observed state of Experiment
+          properties:
+            analysisState:
+              description: AnalysisState is the last recorded analysis state
+              type: object
+            assessment:
+              description: Assessment returned by the last analyis
+              properties:
+                baseline:
+                  description: Assessment details of baseline
+                  properties:
+                    criterion_assessments:
+                      items:
+                        description: CriterionAssessment contains assessment for a
+                          version
+                        properties:
+                          id:
+                            description: Id of version
+                            type: string
+                          metric_id:
+                            description: ID of metric
+                            type: string
+                          statistics:
+                            description: Statistics for this metric
+                            properties:
+                              ratio_statitics:
+                                description: RatioStatistics is statistics for a ratio
+                                  metric
+                                properties:
+                                  credible_interval:
+                                    description: Interval for probability
+                                    properties:
+                                      lower:
+                                        format: float64
+                                        type: number
+                                      upper:
+                                        format: float64
+                                        type: number
+                                    required:
+                                    - lower
+                                    - upper
+                                    type: object
+                                  improvement_over_baseline:
+                                    description: Interval for probability
+                                    properties:
+                                      lower:
+                                        format: float64
+                                        type: number
+                                      upper:
+                                        format: float64
+                                        type: number
+                                    required:
+                                    - lower
+                                    - upper
+                                    type: object
+                                  probability_of_beating_baseline:
+                                    format: float64
+                                    type: number
+                                  probability_of_being_best_version:
+                                    format: float64
+                                    type: number
+                                required:
+                                - credible_interval
+                                - improvement_over_baseline
+                                - probability_of_beating_baseline
+                                - probability_of_being_best_version
+                                type: object
+                              value:
+                                format: float64
+                                type: number
+                            type: object
+                          threshold_assessment:
+                            description: Assessment of how well this metric is doing
+                              with respect to threshold. Defined only for metrics
+                              with a threshold
+                            properties:
+                              probability_of_satisfying_threshold:
+                                description: Probability of satisfying the threshold.
+                                  Defined only for ratio metrics. This is currently
+                                  computed based on Bayesian estimation
+                                format: float64
+                                type: number
+                              threshold_breached:
+                                description: A flag indicating whether threshold is
+                                  breached
+                                type: boolean
+                            required:
+                            - probability_of_satisfying_threshold
+                            - threshold_breached
+                            type: object
+                        required:
+                        - id
+                        - metric_id
+                        type: object
+                      type: array
+                    id:
+                      type: string
+                    name:
+                      description: name of version
+                      type: string
+                    request_count:
+                      format: int32
+                      type: integer
+                    rollback:
+                      description: A flag indicates whether traffic to this target
+                        should be cutoff
+                      type: boolean
+                    weight:
+                      description: Weight of traffic
+                      format: int32
+                      type: integer
+                    win_probability:
+                      format: float64
+                      type: number
+                  required:
+                  - id
+                  - name
+                  - request_count
+                  - weight
+                  - win_probability
+                  type: object
+                candidates:
+                  description: Assessment details of each candidate
+                  items:
+                    description: VersionAssessment contains assessment details for
+                      each version
+                    properties:
+                      criterion_assessments:
+                        items:
+                          description: CriterionAssessment contains assessment for
+                            a version
+                          properties:
+                            id:
+                              description: Id of version
+                              type: string
+                            metric_id:
+                              description: ID of metric
+                              type: string
+                            statistics:
+                              description: Statistics for this metric
+                              properties:
+                                ratio_statitics:
+                                  description: RatioStatistics is statistics for a
+                                    ratio metric
+                                  properties:
+                                    credible_interval:
+                                      description: Interval for probability
+                                      properties:
+                                        lower:
+                                          format: float64
+                                          type: number
+                                        upper:
+                                          format: float64
+                                          type: number
+                                      required:
+                                      - lower
+                                      - upper
+                                      type: object
+                                    improvement_over_baseline:
+                                      description: Interval for probability
+                                      properties:
+                                        lower:
+                                          format: float64
+                                          type: number
+                                        upper:
+                                          format: float64
+                                          type: number
+                                      required:
+                                      - lower
+                                      - upper
+                                      type: object
+                                    probability_of_beating_baseline:
+                                      format: float64
+                                      type: number
+                                    probability_of_being_best_version:
+                                      format: float64
+                                      type: number
+                                  required:
+                                  - credible_interval
+                                  - improvement_over_baseline
+                                  - probability_of_beating_baseline
+                                  - probability_of_being_best_version
+                                  type: object
+                                value:
+                                  format: float64
+                                  type: number
+                              type: object
+                            threshold_assessment:
+                              description: Assessment of how well this metric is doing
+                                with respect to threshold. Defined only for metrics
+                                with a threshold
+                              properties:
+                                probability_of_satisfying_threshold:
+                                  description: Probability of satisfying the threshold.
+                                    Defined only for ratio metrics. This is currently
+                                    computed based on Bayesian estimation
+                                  format: float64
+                                  type: number
+                                threshold_breached:
+                                  description: A flag indicating whether threshold
+                                    is breached
+                                  type: boolean
+                              required:
+                              - probability_of_satisfying_threshold
+                              - threshold_breached
+                              type: object
+                          required:
+                          - id
+                          - metric_id
+                          type: object
+                        type: array
+                      id:
+                        type: string
+                      name:
+                        description: name of version
+                        type: string
+                      request_count:
+                        format: int32
+                        type: integer
+                      rollback:
+                        description: A flag indicates whether traffic to this target
+                          should be cutoff
+                        type: boolean
+                      weight:
+                        description: Weight of traffic
+                        format: int32
+                        type: integer
+                      win_probability:
+                        format: float64
+                        type: number
+                    required:
+                    - id
+                    - name
+                    - request_count
+                    - weight
+                    - win_probability
+                    type: object
+                  type: array
+                winner:
+                  description: Assessment for winner target if exists
+                  properties:
+                    current_best_version:
+                      description: ID of the current winner with the maximum probability
+                        of winning. This is currently computed based on Bayesian estimation
+                      type: string
+                    name:
+                      description: name of winner version
+                      type: string
+                    probability_of_winning_for_best_version:
+                      description: Posterior probability of the version declared as
+                        the current winner. This is None if winner is None. This is
+                        currently computed based on Bayesian estimation
+                      format: float64
+                      type: number
+                    winning_version_found:
+                      description: Indicates whether or not a clear winner has emerged
+                        This is currently computed based on Bayesian estimation and
+                        uses posterior_probability_for_winner from the iteration parameters
+                      type: boolean
+                  required:
+                  - winning_version_found
+                  type: object
+              required:
+              - baseline
+              - candidates
+              type: object
+            conditions:
+              description: List of conditions
+              items:
+                description: ExperimentCondition describes a condition of an experiment
+                properties:
+                  lastTransitionTime:
+                    description: The time when this condition is last updated
+                    format: date-time
+                    type: string
+                  message:
+                    description: Detailed explanation on the update
+                    type: string
+                  reason:
+                    description: Reason for the last update
+                    type: string
+                  status:
+                    description: Status of the condition
+                    type: string
+                  type:
+                    description: Type of the condition
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            currentIteration:
+              description: CurrentIteration is the current iteration number
+              format: int32
+              type: integer
+            effectiveHosts:
+              description: EffectiveHosts is computed host for experiment. List of
+                spec.Service.Name and spec.Service.Hosts[0].name
+              items:
+                type: string
+              type: array
+            endTimestamp:
+              description: EndTimestamp is the timestamp when experiment completes
+              format: date-time
+              type: string
+            experimentType:
+              description: ExperimentType is type of experiment
+              type: string
+            initTimestamp:
+              description: InitTimestamp is the timestamp when the experiment is initialized
+              format: date-time
+              type: string
+            lastUpdateTime:
+              description: LastUpdateTime is the last time iteration has been updated
+              format: date-time
+              type: string
+            message:
+              description: Message specifies message to show in the kubectl printer
+              type: string
+            phase:
+              description: Phase marks the Phase the experiment is at
+              type: string
+            startTimestamp:
+              description: StartTimestamp is the timestamp when the experiment starts
+              format: date-time
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/iter8-operator/1.0.0/iter8.v1.0.0.clusterserviceversion.yaml
+++ b/manifests/iter8-operator/1.0.0/iter8.v1.0.0.clusterserviceversion.yaml
@@ -1,0 +1,308 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: iter8.v1.0.0
+  namespace: iter8
+  annotations:
+    alm-examples: >-
+      [{"apiVersion":"","kind":"Experiment","metadata":{"name":""},"spec":{}},{"apiVersion":"","kind":"Experiment","metadata":{"name":""},"spec":{}}]
+    categories: ''
+    certified: 'false'
+    createdAt: ''
+    description: >-
+      Iter8 is an open-source toolkit for continuous experimentation on
+      Kubernetes. 
+    containerImage: ''
+    support: ''
+    capabilities: Basic Install
+    repository: ''
+spec:
+  displayName: Iter8
+  description: >
+    ## What is an iter8 experiment?
+
+
+    Use an iter8 experiment to safely expose alternative versions of a service
+    to application traffic and intelligently rollout the best version of your
+    service. Iter8’s expressive model of experimentation supports a diverse
+    variety of experiments. The four main kinds of experiments in iter8 are as
+    follows.
+
+
+    - Perform a canary release with two versions, a baseline and a candidate.
+    Iter8 will shift application traffic in a safe and progressive manner to the
+    candidate, if the candidate meets the criteria you specify in the
+    experiment.
+
+
+    - Perform an A/B/n rollout with multiple versions – a baseline and multiple
+    candidates. Iter8 will identify and shift application traffic safely and
+    gradually to the winner, where the winning version is defined by the
+    criteria you specify in your experiments.
+
+
+    - Perform an A/B rollout – this is a special case of the A/B/n rollout
+    described above with a baseline and a single candidate.
+
+
+    - Run a performance test with a single version of a microservice. iter8 will
+    verify if the version meets the criteria you specify in the experiment.
+
+    ## What is iter8?
+
+
+    You are developing a distributed microservices-based application on
+    Kubernetes and have created alternative versions of a service. You want to
+    identify the best version of your service using a live experiment and
+    rollout this version in a safe and reliable manner.
+
+
+    Enter iter8.
+
+
+    Iter8 is an open source toolkit for continuous experimentation on
+    Kubernetes. Iter8 enables you to deliver high-impact code changes within
+    your microservices applications in an agile manner while eliminating the
+    risk. Using iter8’s machine learning (ML)-driven experimentation
+    capabilities, you can safely and rapidly orchestrate various types of live
+    experiments, gain key insights into the behavior of your microservices, and
+    rollout the best versions of your microservices in an automated, principled,
+    and statistically robust manner.
+
+
+    ## Prerequisites for enabling this Operator
+  maturity: beta
+  version: 1.0.0
+  replaces: ''
+  skips: []
+  minKubeVersion: ''
+  keywords: []
+  maintainers:
+    - name: ''
+      email: ''
+  provider:
+    name: Iter8
+  labels: {}
+  selector:
+    matchLabels: {}
+  links:
+    - name: 'iter8 '
+      url: 'https://iter8.tools/'
+  icon:
+    - base64data: ''
+      mediatype: ''
+  customresourcedefinitions:
+    owned:
+      - name: experiments.iter8.tools
+        displayName: Experiment
+        kind: Experiment
+        version: v1alpha2
+        description: Experiment
+        resources:
+          - version: v1
+            kind: Deployment
+          - version: v1
+            kind: Service
+          - version: v1
+            kind: ReplicaSet
+          - version: v1
+            kind: Pod
+          - version: v1
+            kind: Secret
+          - version: v1
+            kind: ConfigMap
+        specDescriptors:
+          - path: analyticsEndpoint
+            description: Analytics Endpoint
+            displayName: Analytics Endpoint
+            x-descriptors: []
+          - path: cleanup
+            description: Cleanup
+            displayName: Cleanup
+            x-descriptors: []
+          - path: criteria
+            description: Criteria
+            displayName: Criteria
+            x-descriptors: []
+          - path: duration
+            description: Duration
+            displayName: Duration
+            x-descriptors: []
+          - path: manualOverride
+            description: Manual Override
+            displayName: Manual Override
+            x-descriptors: []
+          - path: metrics
+            description: Metrics
+            displayName: Metrics
+            x-descriptors: []
+          - path: networking
+            description: Networking
+            displayName: Networking
+            x-descriptors: []
+          - path: service
+            description: Service
+            displayName: Service
+            x-descriptors: []
+          - path: trafficControl
+            description: Traffic Control
+            displayName: Traffic Control
+            x-descriptors: []
+        statusDescriptors:
+          - path: analysisState
+            description: Analysis State
+            displayName: Analysis State
+            x-descriptors: []
+          - path: assessment
+            description: Assessment
+            displayName: Assessment
+            x-descriptors: []
+          - path: conditions
+            description: Conditions
+            displayName: Conditions
+            x-descriptors: []
+          - path: currentIteration
+            description: Current Iteration
+            displayName: Current Iteration
+            x-descriptors: []
+          - path: effectiveHosts
+            description: Effective Hosts
+            displayName: Effective Hosts
+            x-descriptors: []
+          - path: endTimestamp
+            description: End Timestamp
+            displayName: End Timestamp
+            x-descriptors: []
+          - path: experimentType
+            description: Experiment Type
+            displayName: Experiment Type
+            x-descriptors: []
+          - path: initTimestamp
+            description: Init Timestamp
+            displayName: Init Timestamp
+            x-descriptors: []
+          - path: lastUpdateTime
+            description: Last Update Time
+            displayName: Last Update Time
+            x-descriptors: []
+          - path: message
+            description: Message
+            displayName: Message
+            x-descriptors: []
+          - path: phase
+            description: Phase
+            displayName: Phase
+            x-descriptors: []
+          - path: startTimestamp
+            description: Start Timestamp
+            displayName: Start Timestamp
+            x-descriptors: []
+    required: []
+  install:
+    strategy: deployment
+    spec:
+      permissions: []
+      clusterPermissions:
+        - serviceAccountName: iter8-controller
+          rules:
+            - apiGroups: iter8.tools
+              resources:
+                - experiments
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups: ' iter8.tools'
+              resources:
+                - experiments/status
+              verbs:
+                - get
+                - update
+                - patch
+            - apiGroups: networking.istio.io
+              resources:
+                - destinationrules
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups: apps
+              resources:
+                - deployments
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - patch
+                - delete
+            - apiGroups: apps
+              resources:
+                - deployments/status
+              verbs:
+                - get
+                - update
+                - patch
+            - apiGroups: admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+                - validatingwebhookconfigurations
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+      deployments:
+        - name: iter8-controller
+          namespace: iter8
+          labels:
+            app: iter8-controller
+          spec:
+            selector:
+              matchLabels:
+                app: iter8-controller
+            template:
+              metadata:
+                labels:
+                  app: iter8-controller
+              spec:
+                serviceAccountName: iter8-controller
+                containers:
+                  - name: iter8-controller
+                    image: 'iter8/iter8-controller:v1.0.0-rc3'
+                    imagePullPolicy: Always
+                    env:
+                      - name: POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    command:
+                      - /manager
+                    resources:
+                      limits:
+                        cpu: 100m
+                        memory: 75Mi
+                      requests:
+                        cpu: 100m
+                        memory: 50Mi
+                terminationGracePeriodSeconds: 10
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: false

--- a/manifests/iter8-operator/iter8.package.yaml
+++ b/manifests/iter8-operator/iter8.package.yaml
@@ -1,0 +1,5 @@
+packageName: iter8
+channels:
+- name: stable
+  currentCSV: iter8.v1.0.0
+defaultChannel: stable


### PR DESCRIPTION
Starting the OperatorHub Manifests for Iter8.

After we are done here, the contents can be sent to (https://github.com/operator-framework/community-operators/tree/master/community-operators/).

@kalantar, please help me filling some missing fields for Iter8 org (eg: maintainers and maintainers email).

Still need to include config maps inside the iter8 operator code. (`iter8config-notifiers`, `iter8config-metrics`)


The file can be validated on https://operatorhub.io/packages

Closes #2 